### PR TITLE
Merge breaking changes.

### DIFF
--- a/SharpFNT.Tests/CharacterTests.cs
+++ b/SharpFNT.Tests/CharacterTests.cs
@@ -1,0 +1,70 @@
+﻿// ****************************************************************************
+// CharacterTests.cs
+// Copyright 2018 Todd Berta-Oldham
+// This code is licensed under MIT.
+// ****************************************************************************
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace SharpFNT.Tests
+{
+    [TestClass]
+    public class CharacterTests
+    {
+        [TestMethod]
+        public void GetCharacter()
+        {
+            Character character = new Character();
+
+            BitmapFont bitmapFont = new BitmapFont
+            {
+                Characters = new Dictionary<int, Character>
+                {
+                    { 5, character }
+                }
+            };
+
+            Assert.AreEqual(character, bitmapFont.GetCharacter((char)5));
+        }
+
+        [TestMethod]
+        public void GetInvalidCharacter()
+        {
+            Character character = new Character();
+
+            BitmapFont bitmapFont = new BitmapFont
+            {
+                Characters = new Dictionary<int, Character>
+                {
+                    { -1, character }
+                }
+            };
+
+            Assert.AreEqual(character, bitmapFont.GetCharacter((char)5));
+        }
+
+        [TestMethod]
+        public void GetMissingCharacter()
+        {
+            Character character = new Character();
+
+            BitmapFont bitmapFont = new BitmapFont
+            {
+                Characters = new Dictionary<int, Character>
+                {
+                    { -1, character }
+                }
+            };
+
+            Assert.AreEqual(null, bitmapFont.GetCharacter((char)5, false));
+        }
+
+        [TestMethod]
+        public void GetCharacterWhenNull()
+        {
+            BitmapFont bitmapFont = new BitmapFont();
+            Assert.AreEqual(null, bitmapFont.GetCharacter((char)5));
+        }
+    }
+}

--- a/SharpFNT.Tests/IOTests.cs
+++ b/SharpFNT.Tests/IOTests.cs
@@ -129,7 +129,6 @@ namespace SharpFNT.Tests
                         Assert.Fail();
                     }
 
-                    Assert.AreEqual(keyValuePair.Value.ID, value.ID);
                     Assert.AreEqual(keyValuePair.Value.Channel, value.Channel);
                     Assert.AreEqual(keyValuePair.Value.Height, value.Height);
                     Assert.AreEqual(keyValuePair.Value.Page, value.Page);
@@ -155,7 +154,6 @@ namespace SharpFNT.Tests
                     }
 
                     Assert.AreEqual(keyValuePair.Value, value, "One's kerning amount does not equal the two's.");
-                    Assert.AreEqual(keyValuePair.Key.Amount, value, "The kerning amount does not match the property value.");
                 }
             }
         }

--- a/SharpFNT.Tests/IOTests.cs
+++ b/SharpFNT.Tests/IOTests.cs
@@ -16,9 +16,17 @@ namespace SharpFNT.Tests
     public class IOTests
     {
         [TestMethod]
+        public void AutoRead()
+        {
+            Compare(BitmapFont.FromFile("Binary.fnt"), BitmapFont.FromFile("Binary.fnt", FormatHint.Binary));
+            Compare(BitmapFont.FromFile("XML.fnt"), BitmapFont.FromFile("XML.fnt", FormatHint.XML));
+            Compare(BitmapFont.FromFile("Text.fnt"), BitmapFont.FromFile("Text.fnt", FormatHint.Text));
+        }
+
+        [TestMethod]
         public void BinaryWrite()
         {
-            BitmapFont one = BitmapFont.FromFile("Binary.fnt");
+            BitmapFont one = BitmapFont.FromFile("Binary.fnt", FormatHint.Binary);
             BitmapFont two = ReadBackBinary(one);
 
             Compare(one, two);
@@ -27,7 +35,7 @@ namespace SharpFNT.Tests
         [TestMethod]
         public void XMLWrite()
         {
-            BitmapFont one = BitmapFont.FromFile("XML.fnt");
+            BitmapFont one = BitmapFont.FromFile("XML.fnt", FormatHint.XML);
             BitmapFont two = ReadBackXML(one);
 
             Compare(one, two);
@@ -36,7 +44,7 @@ namespace SharpFNT.Tests
         [TestMethod]
         public void TextWrite()
         {
-            BitmapFont one = BitmapFont.FromFile("Text.fnt");
+            BitmapFont one = BitmapFont.FromFile("Text.fnt", FormatHint.Text);
             BitmapFont two = ReadBackText(one);
 
             Compare(one, two);

--- a/SharpFNT.Tests/KerningTests.cs
+++ b/SharpFNT.Tests/KerningTests.cs
@@ -17,7 +17,7 @@ namespace SharpFNT.Tests
         {
             BitmapFont bitmapFont = new BitmapFont
             {
-                KerningPairs = new Dictionary<KerningPair, int> {{new KerningPair(2, 6, 5), 5}}
+                KerningPairs = new Dictionary<KerningPair, int> {{new KerningPair(2, 6), 5}}
             };
 
             int kerningAmount = bitmapFont.GetKerningAmount((char) 2, (char) 6);

--- a/SharpFNT.Tests/KerningTests.cs
+++ b/SharpFNT.Tests/KerningTests.cs
@@ -35,5 +35,43 @@ namespace SharpFNT.Tests
             int kerningAmount = bitmapFont.GetKerningAmount((char)2, (char)6);
             Assert.AreEqual(kerningAmount, 0);
         }
+
+        [TestMethod]
+        public void KerningPairToString()
+        {
+            KerningPair kerningPair = new KerningPair(5, 2);
+            Assert.AreEqual("First: 5, Second: 2", kerningPair.ToString());
+        }
+
+        [TestMethod]
+        public void KerningPairEqualOp()
+        {
+            KerningPair one = new KerningPair(6, 4);
+            KerningPair two = new KerningPair(6, 4);
+            Assert.IsTrue(one == two);
+        }
+
+        [TestMethod]
+        public void KerningPairInequalityOp()
+        {
+            KerningPair one = new KerningPair(6, 4);
+            KerningPair two = new KerningPair(7, 3);
+            Assert.IsTrue(one != two);
+        }
+
+        [TestMethod]
+        public void KerningPairEqualNotKerningPair()
+        {
+            object one = new object();
+            KerningPair two = new KerningPair(2, 4);
+            Assert.IsFalse(two.Equals(one));
+        }
+
+        [TestMethod]
+        public void KerningPairEqualNull()
+        {
+            KerningPair two = new KerningPair(2, 4);
+            Assert.IsFalse(two.Equals(null));
+        }
     }
 }

--- a/SharpFNT.Tests/UtilityExtensionTests.cs
+++ b/SharpFNT.Tests/UtilityExtensionTests.cs
@@ -1,0 +1,56 @@
+﻿// ****************************************************************************
+// UtilityTests.cs
+// Copyright 2018 Todd Berta-Oldham
+// This code is licensed under MIT.
+// ****************************************************************************
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace SharpFNT.Tests
+{
+    [TestClass]
+    public class UtilityExtensionTests
+    {
+        [TestMethod]
+        public void ReadBit()
+        {
+            const byte testNumber = 0b0010000;
+            Assert.IsTrue(testNumber.IsBitSet(4));
+        }
+
+        [TestMethod]
+        public void WriteBitTrue()
+        {
+            const byte expected = 0b0100;
+            byte value = 0;
+            value = value.SetBit(2, true);
+            Assert.AreEqual(expected, value);
+        }
+
+        [TestMethod]
+        public void WriteBitFalse()
+        {
+            const byte expected = 0b01111111;
+            byte value = 0b11111111;
+            value = value.SetBit(7, false);
+            Assert.AreEqual(expected, value);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void WriteBitOutOfRange()
+        {
+            const byte value = 0;
+            value.SetBit(int.MaxValue, true);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentOutOfRangeException))]
+        public void ReadBitOutOfRange()
+        {
+            const byte value = 0;
+            value.IsBitSet(int.MaxValue);
+        }
+    }
+}

--- a/SharpFNT/BitmapFont.cs
+++ b/SharpFNT/BitmapFont.cs
@@ -8,9 +8,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Xml;
 using System.Xml.Linq;
+
+[assembly: InternalsVisibleTo("SharpFNT.Tests")]
 
 namespace SharpFNT
 {

--- a/SharpFNT/Character.cs
+++ b/SharpFNT/Character.cs
@@ -14,7 +14,6 @@ namespace SharpFNT
     {
         public const int SizeInBytes = 20;
 
-        public int ID { get; set; }
         public int X { get; set; }
         public int Y { get; set; }
         public int Width { get; set; }
@@ -25,9 +24,9 @@ namespace SharpFNT
         public int Page { get; set; }
         public Channel Channel { get; set; }
 
-        public void WriteBinary(BinaryWriter binaryWriter) 
+        public void WriteBinary(BinaryWriter binaryWriter, int id) 
         {
-            binaryWriter.Write((uint)this.ID);
+            binaryWriter.Write((uint)id);
             binaryWriter.Write((ushort)this.X);
             binaryWriter.Write((ushort)this.Y);
             binaryWriter.Write((ushort)this.Width);
@@ -38,9 +37,9 @@ namespace SharpFNT
             binaryWriter.Write((byte)this.Page);
             binaryWriter.Write((byte)this.Channel);
         }
-        public void WriteXML(XElement element) 
+        public void WriteXML(XElement element, int id) 
         {
-            element.SetAttributeValue("id", this.ID);
+            element.SetAttributeValue("id", id);
             element.SetAttributeValue("x", this.X);
             element.SetAttributeValue("y", this.Y);
             element.SetAttributeValue("width", this.Width);
@@ -51,9 +50,9 @@ namespace SharpFNT
             element.SetAttributeValue("page", this.Page);
             element.SetAttributeValue("chnl", (int)this.Channel);
         }
-        public void WriteText(TextWriter textWriter)
+        public void WriteText(TextWriter textWriter, int id)
         {
-            TextFormatUtility.WriteInt("id", this.ID, textWriter);
+            TextFormatUtility.WriteInt("id", id, textWriter);
             TextFormatUtility.WriteInt("x", this.X, textWriter);
             TextFormatUtility.WriteInt("y", this.Y, textWriter);
             TextFormatUtility.WriteInt("width", this.Width, textWriter);
@@ -65,11 +64,12 @@ namespace SharpFNT
             TextFormatUtility.WriteEnum("chnl", this.Channel, textWriter);
         }
 
-        public static Character ReadBinary(BinaryReader binaryReader)
+        public static Character ReadBinary(BinaryReader binaryReader, out int id)
         {
+            id = (int)binaryReader.ReadUInt32();
+
             return new Character
             {
-                ID = (int)binaryReader.ReadUInt32(),
                 X = binaryReader.ReadUInt16(),
                 Y = binaryReader.ReadUInt16(),
                 Width = binaryReader.ReadUInt16(),
@@ -78,14 +78,15 @@ namespace SharpFNT
                 YOffset = binaryReader.ReadInt16(),
                 XAdvance = binaryReader.ReadInt16(),
                 Page = binaryReader.ReadByte(),
-                Channel = (Channel)binaryReader.ReadByte()
+                Channel = (Channel) binaryReader.ReadByte()
             };
         }
-        public static Character ReadXML(XElement element)
+        public static Character ReadXML(XElement element, out int id)
         {
+            id = (int) element.Attribute("id");
+
             return new Character
             {
-                ID = (int)element.Attribute("id"),
                 X = (int)element.Attribute("x"),
                 Y = (int)element.Attribute("y"),
                 Width = (int)element.Attribute("width"),
@@ -97,11 +98,12 @@ namespace SharpFNT
                 Channel = element.Attribute("chnl").GetEnumValue<Channel>()
             };
         }
-        public static Character ReadText(IReadOnlyList<string> lineSegments) 
+        public static Character ReadText(IReadOnlyList<string> lineSegments, out int id)
         {
+            id = TextFormatUtility.ReadInt("id", lineSegments);
+
             return new Character
             {
-                ID = TextFormatUtility.ReadInt("id", lineSegments),
                 X = TextFormatUtility.ReadInt("x", lineSegments),
                 Y = TextFormatUtility.ReadInt("y", lineSegments),
                 Width = TextFormatUtility.ReadInt("width", lineSegments),

--- a/SharpFNT/KerningPair.cs
+++ b/SharpFNT/KerningPair.cs
@@ -17,32 +17,30 @@ namespace SharpFNT
 
         public int First { get; }
         public int Second { get; }
-        public int Amount { get; }
 
-        public KerningPair(int first, int second, int amount)
+        public KerningPair(int first, int second)
         {
             this.First = first;
             this.Second = second;
-            this.Amount = amount;
         }
 
-        public void WriteBinary(BinaryWriter binaryWriter)
+        public void WriteBinary(BinaryWriter binaryWriter, int amount)
         {
             binaryWriter.Write((uint)this.First);
             binaryWriter.Write((uint)this.Second);
-            binaryWriter.Write((short)this.Amount);
+            binaryWriter.Write((short)amount);
         }
-        public void WriteXML(XElement element) 
+        public void WriteXML(XElement element, int amount) 
         {
             element.SetAttributeValue("first", this.First);
             element.SetAttributeValue("second", this.Second);
-            element.SetAttributeValue("amount", this.Amount);
+            element.SetAttributeValue("amount", amount);
         }
-        public void WriteText(TextWriter textWriter)
+        public void WriteText(TextWriter textWriter, int amount)
         {
             TextFormatUtility.WriteInt("first", this.First, textWriter);
             TextFormatUtility.WriteInt("second", this.Second, textWriter);
-            TextFormatUtility.WriteInt("amount", this.Amount, textWriter);
+            TextFormatUtility.WriteInt("amount", amount, textWriter);
         }
 
         public bool Equals(KerningPair other)
@@ -65,7 +63,6 @@ namespace SharpFNT
         {
             return left.Equals(right);
         }
-
         public static bool operator !=(KerningPair left, KerningPair right)
         {
             return !left.Equals(right);
@@ -73,31 +70,32 @@ namespace SharpFNT
 
         public override string ToString()
         {
-            return $"{nameof(this.First)}: {this.First}, {nameof(this.Second)}: {this.Second}, {nameof(this.Amount)}: {this.Amount}";
+            return $"{nameof(this.First)}: {this.First}, {nameof(this.Second)}: {this.Second}";
         }
 
-        public static KerningPair ReadBinary(BinaryReader binaryReader)
+        public static KerningPair ReadBinary(BinaryReader binaryReader, out int amount)
         {
             int first = (int)binaryReader.ReadUInt32();
             int second = (int)binaryReader.ReadUInt32();
-            short amount = binaryReader.ReadInt16();
-            return new KerningPair(first, second, amount);
+            amount = binaryReader.ReadInt16();
+
+            return new KerningPair(first, second);
         }
-        public static KerningPair ReadXML(XElement element)
+        public static KerningPair ReadXML(XElement element, out int amount)
         {
             int first = (int)element.Attribute("first");
             int second = (int)element.Attribute("second"); 
-            int amount = (int)element.Attribute("amount");
+            amount = (int)element.Attribute("amount");
 
-            return new KerningPair(first, second, amount); 
+            return new KerningPair(first, second); 
         }
-        public static KerningPair ReadText(IReadOnlyList<string> lineSegments)
+        public static KerningPair ReadText(IReadOnlyList<string> lineSegments, out int amount)
         {
             int first = TextFormatUtility.ReadInt("first", lineSegments);
             int second = TextFormatUtility.ReadInt("second", lineSegments);
-            int amount = TextFormatUtility.ReadInt("amount", lineSegments);
+            amount = TextFormatUtility.ReadInt("amount", lineSegments);
 
-            return new KerningPair(first, second, amount);
+            return new KerningPair(first, second);
         }
     }
 }

--- a/SharpFNT/UtilityExtensions.cs
+++ b/SharpFNT/UtilityExtensions.cs
@@ -20,6 +20,8 @@ namespace SharpFNT
         }
         public static byte SetBit(this byte @byte, int index, bool set)
         {
+            if (index < 0 || index > 7) throw new ArgumentOutOfRangeException(nameof(index));
+
             if (set)
             {
                 return (byte)(@byte | (1 << index));


### PR DESCRIPTION
This pull request removes the ID property from Character and the Amount property from KerningPair. Having these values stored in dictionaries and as properties can lead to unexpected behavior when writing if only one is updated. The dictionaries are necessary for performance, so it is best to just remove the properties. If a project does use these properties, which is unlikely, they shouldn't have too much trouble updating their code.