### PR TITLE
Fix Info block length in binary format

### DIFF
--- a/SharpFNT/BitmapFontInfo.cs
+++ b/SharpFNT/BitmapFontInfo.cs
@@ -39,7 +39,7 @@ namespace SharpFNT
 
         public void WriteBinary(BinaryWriter binaryWriter)
         {
-            binaryWriter.Write(MinSizeInBytes + (Face?.Length ?? 0) + 1);
+            binaryWriter.Write(MinSizeInBytes + (Face?.Length ?? 0));
             binaryWriter.Write((short)Size);
 
             byte bitField = 0;


### PR DESCRIPTION
MinSizeInBytes already includes the null terminator: fixed fields take 14 bytes, according to the format specification